### PR TITLE
Language override for highlighting codeblocks

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -105,10 +105,18 @@ marked.setOptions(
 	sanitize: false,
 	smartLists: true,
 	smartypants: true,
-	highlight: function(code) //use highlight.js for syntax highlighting. 
-	{
-		return highlight.highlightAuto(code).value;
-	}
+	highlight: function(code, lang) //use highlight.js for syntax highlighting. 
+	{   
+        	try
+        	{
+            		content = highlight.highlight(lang, code).value;
+        	}
+        	catch (err)
+        	{
+            		content = highlight.highlightAuto(code).value;
+        	}
+        	return content;
+    	} 
 });
 
 $(document).on("click", "list-item", function()

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -106,7 +106,9 @@ marked.setOptions(
 	smartLists: true,
 	smartypants: true,
 	highlight: function(code, lang) //use highlight.js for syntax highlighting. 
-	{   
+	{
+		if (!lang) return highlight.highlightAuto(code).value;
+        	
         	try
         	{
             		content = highlight.highlight(lang, code).value;


### PR DESCRIPTION
Added to the marked.setOptions of app.js to handle language overrides for code blocks. (```)